### PR TITLE
Fix bugs when parse the sweeps only files and the regular expression mistake  for the real value

### DIFF
--- a/psf_utils/parse.py
+++ b/psf_utils/parse.py
@@ -18,7 +18,6 @@ Parse ASCII PSF Files
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 
-
 # Imports {{{1
 import ply.lex
 import ply.yacc
@@ -144,10 +143,10 @@ reserved = {rw: rw for rw in [
     'VALUE',
 ]}
 tokens = [
-             'INTEGER',
-             'REAL',
-             'STRING',
-         ] + list(reserved.values())
+    'INTEGER',
+    'REAL',
+    'STRING',
+] + list(reserved.values())
 
 # Literal tokens
 literals = r'()'

--- a/psf_utils/parse.py
+++ b/psf_utils/parse.py
@@ -103,7 +103,7 @@ class TokenLocation(object):
                 self.line,
                 self.col*' '
             )
-        return "%s\n%s^" % (self.line, (self.col-1) * ' ')
+        return "%s\n%s^" % (self.line, (self.col-1)*' ')
 
     def message(self, filename, msg):
         """

--- a/psf_utils/parse.py
+++ b/psf_utils/parse.py
@@ -24,7 +24,6 @@ import ply.lex
 import ply.yacc
 from inform import Info, is_str, is_mapping
 
-
 # Globals {{{1
 Filename = None
 
@@ -101,9 +100,9 @@ class TokenLocation(object):
             return "%s\n    %s\n    %s^" % (
                 prefix,
                 self.line,
-                self.col*' '
+                self.col * ' '
             )
-        return "%s\n%s^" % (self.line, (self.col-1)*' ')
+        return "%s\n%s^" % (self.line, (self.col - 1) * ' ')
 
     def message(self, filename, msg):
         """
@@ -145,10 +144,10 @@ reserved = {rw: rw for rw in [
     'VALUE',
 ]}
 tokens = [
-    'INTEGER',
-    'REAL',
-    'STRING',
-] + list(reserved.values())
+             'INTEGER',
+             'REAL',
+             'STRING',
+         ] + list(reserved.values())
 
 # Literal tokens
 literals = r'()'
@@ -156,7 +155,7 @@ literals = r'()'
 # Regular expression tokens
 # Regular expressions that define numbers
 t_INTEGER = r"-?[0-9]+"
-t_REAL = r"[+-]?[0-9]+\.[0-9]*([eE][+-][0-9]+)?"
+t_REAL = r"([+-]?[0-9]*\.[0-9]*([eE][+-]?[0-9]+)?)|([+-]?[0-9]*\.?[0-9]*[eE][+-]?[0-9]+)"
 t_NAN = r"nan|NaN"
 
 # Regular expression for a string
@@ -186,12 +185,22 @@ def t_error(t):
 
 
 # Parser {{{1
-def p_contents(p):
+def p_contents_sweep_trace_value(p):
     "contents : header_section type_section sweep_section trace_section value_section end"
     p[0] = (p[1], p[2], p[3], p[4], p[5])
 
 
-def p_contents_without_sweep(p):
+def p_contents_sweep_value(p):
+    "contents : header_section type_section sweep_section value_section end"
+    p[0] = (p[1], p[2], p[3], None, p[4])
+
+
+def p_contents_trace_value(p):
+    "contents : header_section type_section trace_section value_section end"
+    p[0] = (p[1], p[2], None, p[3], p[4])
+
+
+def p_contents_value(p):
     "contents : header_section type_section value_section end"
     p[0] = (p[1], p[2], None, None, p[3])
 

--- a/psf_utils/parse.py
+++ b/psf_utils/parse.py
@@ -18,10 +18,12 @@ Parse ASCII PSF Files
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see http://www.gnu.org/licenses/.
 
+
 # Imports {{{1
 import ply.lex
 import ply.yacc
 from inform import Info, is_str, is_mapping
+
 
 # Globals {{{1
 Filename = None
@@ -99,9 +101,9 @@ class TokenLocation(object):
             return "%s\n    %s\n    %s^" % (
                 prefix,
                 self.line,
-                self.col * ' '
+                self.col*' '
             )
-        return "%s\n%s^" % (self.line, (self.col - 1) * ' ')
+        return "%s\n%s^" % (self.line, (self.col-1) * ' ')
 
     def message(self, filename, msg):
         """

--- a/psf_utils/psf.py
+++ b/psf_utils/psf.py
@@ -19,14 +19,15 @@ Read PSF File
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 
+# Imports {{{1
+from .parse import ParsePSF, ParseError
+from inform import Error, Info, join, log, os_error
 from pathlib import Path
 
 import numpy as np
-from inform import Error, Info, join, log, os_error
+
 from quantiphy import Quantity
 
-# Imports {{{1
-from .parse import ParsePSF, ParseError
 
 try:
     import cPickle as pickle
@@ -111,8 +112,8 @@ class PSF:
         except UnicodeError as e:
             raise Error(
                 e,
-                culprit=psf_filepath,
-                codicil=join(
+                culprit = psf_filepath,
+                codicil = join(
                     'This is likely a binary PSF file,',
                     'psf_utils only supports ASCII PSF files.',
                     '\nUse `psf {0!s} {0!s}.ascii` to convert.'.format(psf_filepath),
@@ -161,12 +162,12 @@ class PSF:
                     else:
                         ordinate = np.array([get_value(v, i) for v in vals])
                     signal = Signal(
-                        name=joined_name,
-                        ordinate=ordinate,
-                        type=t,
-                        access=t.name,
-                        units=t.units,
-                        meta=meta,
+                        name = joined_name,
+                        ordinate = ordinate,
+                        type = t,
+                        access = t.name,
+                        units = t.units,
+                        meta = meta,
                     )
                     signals[joined_name] = signal
                 del values[name]
@@ -180,22 +181,22 @@ class PSF:
                         n = f'{name}.{t.name}'
                         v = Quantity(v, unicode_units(t.units))
                         signal = Signal(
-                            name=n,
-                            ordinate=v,
-                            type=t,
-                            units=t.units,
-                            meta=meta,
+                            name = n,
+                            ordinate = v,
+                            type = t,
+                            units = t.units,
+                            meta = meta,
                         )
                         signals[n] = signal
                 else:
                     v = Quantity(value.values[0][0], unicode_units(type.units))
                     signal = Signal(
-                        name=name,
-                        ordinate=v,
-                        type=type,
-                        access=type.name,
-                        units=type.units,
-                        meta=meta,
+                        name = name,
+                        ordinate = v,
+                        type = type,
+                        access = type.name,
+                        units = type.units,
+                        meta = meta,
                     )
                     signals[name] = signal
         self.signals = signals

--- a/psf_utils/psf.py
+++ b/psf_utils/psf.py
@@ -19,12 +19,15 @@ Read PSF File
 # along with this program.  If not, see [http://www.gnu.org/licenses/].
 
 
+from pathlib import Path
+
+import numpy as np
+from inform import Error, Info, join, log, os_error
+from quantiphy import Quantity
+
 # Imports {{{1
 from .parse import ParsePSF, ParseError
-from inform import Error, Info, join, log, os_error
-from pathlib import Path
-import numpy as np
-from quantiphy import Quantity
+
 try:
     import cPickle as pickle
 except ImportError:
@@ -108,8 +111,8 @@ class PSF:
         except UnicodeError as e:
             raise Error(
                 e,
-                culprit = psf_filepath,
-                codicil = join(
+                culprit=psf_filepath,
+                codicil=join(
                     'This is likely a binary PSF file,',
                     'psf_utils only supports ASCII PSF files.',
                     '\nUse `psf {0!s} {0!s}.ascii` to convert.'.format(psf_filepath),
@@ -158,17 +161,17 @@ class PSF:
                     else:
                         ordinate = np.array([get_value(v, i) for v in vals])
                     signal = Signal(
-                        name = joined_name,
-                        ordinate = ordinate,
-                        type = t,
-                        access = t.name,
-                        units = t.units,
-                        meta = meta,
+                        name=joined_name,
+                        ordinate=ordinate,
+                        type=t,
+                        access=t.name,
+                        units=t.units,
+                        meta=meta,
                     )
                     signals[joined_name] = signal
                 del values[name]
-        else:
-            # no traces, this should be a DC op-point analysis dataset
+        if traces is None and sweeps is None:
+            # no traces and no sweeps, this should be a DC op-point analysis dataset
             for name, value in values.items():
                 assert len(value.values) == 1
                 type = types[value.type]
@@ -177,22 +180,22 @@ class PSF:
                         n = f'{name}.{t.name}'
                         v = Quantity(v, unicode_units(t.units))
                         signal = Signal(
-                            name = n,
-                            ordinate = v,
-                            type = t,
-                            units = t.units,
-                            meta = meta,
+                            name=n,
+                            ordinate=v,
+                            type=t,
+                            units=t.units,
+                            meta=meta,
                         )
                         signals[n] = signal
                 else:
                     v = Quantity(value.values[0][0], unicode_units(type.units))
                     signal = Signal(
-                        name = name,
-                        ordinate = v,
-                        type = type,
-                        access = type.name,
-                        units = type.units,
-                        meta = meta,
+                        name=name,
+                        ordinate=v,
+                        type=type,
+                        access=type.name,
+                        units=type.units,
+                        meta=meta,
                     )
                     signals[name] = signal
         self.signals = signals

--- a/psf_utils/psf.py
+++ b/psf_utils/psf.py
@@ -25,7 +25,6 @@ from inform import Error, Info, join, log, os_error
 from pathlib import Path
 import numpy as np
 from quantiphy import Quantity
-
 try:
     import cPickle as pickle
 except ImportError:

--- a/psf_utils/psf.py
+++ b/psf_utils/psf.py
@@ -23,11 +23,8 @@ Read PSF File
 from .parse import ParsePSF, ParseError
 from inform import Error, Info, join, log, os_error
 from pathlib import Path
-
 import numpy as np
-
 from quantiphy import Quantity
-
 
 try:
     import cPickle as pickle


### PR DESCRIPTION
Resolve the bug bellow:

* The spectre do not generate the `TRACE` section for the sweep only scene, especially one sweep in the parent sweep way.

* The regular expression mistake  for the real value.  Some other simulation tools can generate value like `1e-2` and `.1e-2`.