### PR TITLE
Reduce memory usage

### DIFF
--- a/psf_utils/parse.py
+++ b/psf_utils/parse.py
@@ -435,23 +435,21 @@ def p_trace_with_props(p):
 
 def p_value_section(p):
     "value_section : VALUE values"
-    values = {}
-    for n, t, v in p[2]:
-        if n not in values:
-            values[n] = Value(type=t, values=[])
-        values[n].values.append(v)
-    p[0] = values
+    p[0] = p[2]
 
 
 def p_values(p):
     "values : values signal_value"
-    p[1].append(p[2])
+    if p[2][0] not in p[1]:
+        p[1][p[2][0]] = Value(type=p[2][1], values=[p[2][2]])
+    else:
+        p[1][p[2][0]].values.append(p[2][2])
     p[0] = p[1]
 
 
 def p_values_last(p):
     "values : signal_value"
-    p[0] = [p[1]]
+    p[0] = {p[1][0]: Value(type=p[1][1], values=[p[1][2]])}
 
 
 def p_named_signal_scalar(p):


### PR DESCRIPTION
Currently, all values are first all parsed (name, type, value) and then the values of the same signals are put into a list. This wastes memory as the name and type are stored unnecessarily multiple times in the memory. I've changed the parser functions so that the `Value` class is directly created when a value is parsed. Further values are then just added to the list in the class.

I've verified the memory usage with the following code:

```python
from psf_utils import PSF
import resource

idle = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss/1024

psf = PSF("tran.tran.tran", use_cache=False)
print(psf)

print(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss/1024 - idle)
```

The used file has a size of 18 MB. My changes improve the reported memory usage from ~99 MB to ~53 MB.
